### PR TITLE
Fix the path of symlink and install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ mkdir -p ~/.config/mkctf && cp -r /tmp/mkctf/config/* ~/.config/mkctf/
 mkctf-cli -h
 ```
 
+Please ensure that `~/bin` is part of your `PATH`.
+
+```bash
+export PATH="<your bin path>:$PATH"
+```
+
 Then lets say you want to create a CTF for INS'hAck 2020:
 
 ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -33,10 +33,15 @@ if [ ! -d ${VENV_DIR} ]; then
     print "creating a Python 3 virtual environment"
     python3 -m venv ${VENV_DIR}
 fi
+print "Install dependencies"
+${VENV_DIR}/bin/pip install --upgrade pip
+${VENV_DIR}/bin/pip install wheel
+${VENV_DIR}/bin/pip install multidict attrs yarl async_timeout charset-normalizer aiosignal
+${VENV_DIR}/bin/pip install MarkupSafe==2.0.0
 print "installing/updating mkCTF in the venv"
 ${VENV_DIR}/bin/pip install -U ${LOCAL_REPO}
 print "creating/updating symbolic links for mkctf scripts"
-ln -sf ./mkctf-venv/bin/mkctf-* .
+ln -sf ./.mkctf-venv/bin/mkctf-* .
 print "leaving ${BIN_DIR}"
 cd ${CWD}
 # -- installing mkctf configuration


### PR DESCRIPTION
Hi koromodako,

The command to create symlink in the original `setup.sh` uses a source file path missing a `.`. I fixed that and also added the commands to upgrade `pip` and install dependencies.

Sincerely,
Anais